### PR TITLE
Add tryExclusiveLock, tryUpgradeLock, downgradeLock and prevent reader starvation with write barrier

### DIFF
--- a/CPP/locks/DCLCRWLock.h
+++ b/CPP/locks/DCLCRWLock.h
@@ -37,6 +37,8 @@ public:
     void exclusiveLock(void);
     bool tryExclusiveLock(void);
     bool exclusiveUnlock(void);
+    bool downgradeLock(void);
+    bool tryUpgradeLock(void);
 
 private:
     int thread2idx(void);

--- a/CPP/locks/DCLCRWLock.h
+++ b/CPP/locks/DCLCRWLock.h
@@ -35,6 +35,7 @@ public:
     bool trySharedLock(void);
     bool sharedUnlock(void);
     void exclusiveLock(void);
+    bool tryExclusiveLock(void);
     bool exclusiveUnlock(void);
 
 private:


### PR DESCRIPTION
Hi,

thank you for all the code you publish!

I've been implementing C-RW-WP in C11 based on your code and here are few extra things I needed:

* ::tryExclusiveLock has been implemented
* Writer Barrier has been implemented (based on the paper) to prevent starving the readers
* ::tryUpgradeLock and ::downgradeLock has been implemented (I am just not sure about the naming)

The paper also talks about replacing the readersCounters with ingress and egress counters to remove the intra-node contention - I can also do that, but for our purposes the code works fine.

I can also submit the C11 code if you want - I would just need to clean it up a bit, because it's currently plugged in into BIND 9 code.