### PR TITLE
Fix broken link to research paper in FAAArrayQueue.java

### DIFF
--- a/Java/com/concurrencyfreaks/queues/array/FAAArrayQueue.java
+++ b/Java/com/concurrencyfreaks/queues/array/FAAArrayQueue.java
@@ -72,7 +72,7 @@ import com.concurrencyfreaks.queues.IQueue;
  * <p>
  * The paper on Hazard Pointers is named "Hazard Pointers: Safe Memory
  * Reclamation for Lock-Free objects" and it is available here:
- * http://web.cecs.pdx.edu/~walpole/class/cs510/papers/11.pdf
+ * https://web.archive.org/web/20140216055028/http://web.cecs.pdx.edu/~walpole/class/cs510/papers/11.pdf
  *
  * @author Pedro Ramalhete
  * @author Andreia Correia


### PR DESCRIPTION
## Description
Fixes broken link to research paper in FAAArrayQueue.java comments.

The original link (http://web.cecs.pdx.edu/~walpole/class/cs510/papers/11.pdf) returns 404. 
Replaced with Web Archive version.

Fixes #14

## Changes
- Line 75: Updated link to https://web.archive.org/web/20140216055028/http://web.cecs.pdx.edu/~walpole/class/cs510/papers/11.pdf
